### PR TITLE
Fixed liquidbase changelo-master typo

### DIFF
--- a/fincon-starter-app/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/fincon-starter-app/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,4 +3,5 @@ databaseChangeLog:
       file: db/changelog/db-properties.xml
   - include:
       file: db/changelog/db-structure.xml
+  - include:
       file: db/changelog/db-01.xml


### PR DESCRIPTION
Liquidbase migrations should work as intended with this change (if they didn't before which they didn't for me).